### PR TITLE
Redesign Class Construction

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ $jenkins = new \ooobii\Jenkins($host, $port = NULL, $useHttps = TRUE, $user = NU
 ```
 **_OR:_**
 ```php
-use \ooobii\Jenkins;a
+use \ooobii\Jenkins;
 ...
 $jenkins = new Jenkins($host, $port = NULL, $useHttps = TRUE, $user = NULL, $token = NULL);
 ```

--- a/README.md
+++ b/README.md
@@ -52,23 +52,18 @@ php composer-setup.php --install-dir=/usr/local/bin --filename=composer
 Before anything, you need to instantiate the client:
 
 ```php
-$jenkins = new \ooobii\Jenkins('http://host.org:8080');
+$jenkins = new \ooobii\Jenkins($host, $port = NULL, $useHttps = TRUE, $user = NULL, $token = NULL);
 ```
 **_OR:_**
 ```php
-use \ooobii\Jenkins;
+use \ooobii\Jenkins;a
 ...
-$jenkins = new Jenkins('http://host.org:8080');
+$jenkins = new Jenkins($host, $port = NULL, $useHttps = TRUE, $user = NULL, $token = NULL);
 ```
 
-If your Jenkins needs authentication, you need to pass a URL like this : `'http://user:token@host.org:8080'`.
+### Usage Examples
 
-
-Here are some examples of how to use it:
-
-
-Get the color of the job
-------------------------
+#### Get the color of the job
 
 ```php
     $job = $jenkins->getJob("dev2-pull");
@@ -77,8 +72,7 @@ Get the color of the job
 ```
 
 
-Launch a Job
-------------
+#### Launch a Job
 
 ```php
     $job = $jenkins->launchJob("clone-deploy");
@@ -87,8 +81,7 @@ Launch a Job
 ```
 
 
-List the jobs of a given view
------------------------------
+#### List the jobs of a given view
 
 ```php
     $view = $jenkins->getView('madb_deploy');
@@ -101,8 +94,7 @@ List the jobs of a given view
     //string(11) "fedora-pull"
 ```
 
-List builds and their status
-----------------------------
+#### List builds and their status
 
 ```php
     $job = $jenkins->getJob('dev2-pull');
@@ -117,8 +109,7 @@ List builds and their status
 ```
 
 
-Check if Jenkins is available
------------------------------
+#### Check if Jenkins is available
 
 ```php
     var_dump($jenkins->isAvailable());
@@ -126,9 +117,3 @@ Check if Jenkins is available
 ```
 
 For more information, see the [Jenkins API](https://wiki.jenkins-ci.org/display/JENKINS/Remote+access+API).
-
-
-Coding standards
-----------------
-
-This projects follows PSR-0, PSR-1, PSR-2, PSR-4

--- a/src/Jenkins.php
+++ b/src/Jenkins.php
@@ -44,11 +44,60 @@ class Jenkins
     private $crumbRequestField;
 
     /**
-     * @param string $baseUrl
+     * Create a new instance of the Jenkins management interface class.
+     * 
+     * Uses the provided parameters to formulate the URL used for API requests.
+     *
+     * @param string $host The DNS hostname or TCP/IP address of the Jenkins host to connect to.
+     * @param boolean $useHttps Set to `TRUE` if the Jenkins instance you're connecting to does not allow regular HTTP traffic.
+     * @param string|null $user *(Required if API needs authentication)* The username to impersonate when connecting to the Jenkins API.
+     * @param string|null $token *(Required if API needs authentication)* An API token that belongs to the user to impersonate for Jenkins API communications.
+     * @param int $port The TCP/IP port number to send the HTTP/HTTPS requests through.
+     *   * If the port number is not specified, the default port number for the selected HTTP/HTTPS transmission method will be used.
+     *   * If a port number is specified, the number provided will be included in the constructed API URL.
+     * 
      */
-    public function __construct($baseUrl)
-    {
+    public function __construct($host, $useHttps = TRUE, $user = NULL, $token = NULL, $port = NULL) {
+
+        //make sure host parameter is populated.
+        if(!$host || strlen($host) < 1)
+            throw new \Exception("Unable to create new Jenkins management class; Invalid DNS hostname or IP address provided.");
+
+        //make sure that, if provided, the username is not empty.
+        if($user !== NULL && strlen($user) < 1)
+            throw new \Exception("Unable to create new Jenkins management class; Invalid username provided.");
+
+        //make sure that, if provided, the username is not empty.
+        if($token !== NULL && strlen($token) < 1)
+            throw new \Exception("Unable to create new Jenkins management class; Invalid token provided.");
+
+        //make sure that, if provided, the username is not empty.
+        if($port !== NULL && (!is_numeric($port) || $port < 1 || $port > 65535))
+            throw new \Exception("Unable to create new Jenkins management class; Invalid port provided.");
+
+
+        //use HTTP or HTTPS based on provided argument.
+        $baseUrl = "https://";
+        $useHttps or $baseUrl = "http://";
+    
+        //if a username is provided, append it to the URL.
+        if($user) $baseUrl .= $user;
+    
+        //if a token is provided, append it to the URL.
+        if($token) $baseUrl .= ':' . $token;
+    
+        //if either a token or username was provided, add the identity separator to the URL.
+        if($user || $token) $baseUrl .= '@';
+    
+        //append the hostname of the Jenkins instance to the URL.
+        $baseUrl .= $host;
+    
+        //if a port was set, append it to the output URL.
+        if($port) $baseUrl .= ':' . $port;
+
+        //now that URL is compiled, set the base URL.
         $this->baseUrl = $baseUrl;
+
     }
 
     /**

--- a/src/Jenkins.php
+++ b/src/Jenkins.php
@@ -63,7 +63,7 @@ class Jenkins
         if(!$host || strlen($host) < 1)
             throw new \Exception("Unable to create new Jenkins management class; Invalid DNS hostname or IP address provided.");
 
-        //make sure that, if provided, the username is not empty.
+        //make sure that, if provided, the port number is a valid value.
         if($port !== NULL && (!is_numeric($port) || $port < 1 || $port > 65535))
             throw new \Exception("Unable to create new Jenkins management class; Invalid port provided.");
 
@@ -71,8 +71,8 @@ class Jenkins
         if($user !== NULL && strlen($user) < 1)
             throw new \Exception("Unable to create new Jenkins management class; Invalid username provided.");
 
-        //make sure that, if provided, the username is not empty.
-        if($token !== NULL && strlen($token) < 1)
+        //make sure that, if provided, the token is not empty.
+        if($token !== NULL && empty(trim($token)))
             throw new \Exception("Unable to create new Jenkins management class; Invalid token provided.");
 
 
@@ -84,7 +84,7 @@ class Jenkins
         if($user) $baseUrl .= $user;
     
         //if a token is provided, append it to the URL.
-        if($token) $baseUrl .= ':' . $token;
+        if($token) $baseUrl .= ':' . trim($token);
     
         //if either a token or username was provided, add the identity separator to the URL.
         if($user || $token) $baseUrl .= '@';

--- a/src/Jenkins.php
+++ b/src/Jenkins.php
@@ -57,11 +57,15 @@ class Jenkins
      *   * If a port number is specified, the number provided will be included in the constructed API URL.
      * 
      */
-    public function __construct($host, $useHttps = TRUE, $user = NULL, $token = NULL, $port = NULL) {
+    public function __construct($host, $port = NULL, $useHttps = TRUE, $user = NULL, $token = NULL) {
 
         //make sure host parameter is populated.
         if(!$host || strlen($host) < 1)
             throw new \Exception("Unable to create new Jenkins management class; Invalid DNS hostname or IP address provided.");
+
+        //make sure that, if provided, the username is not empty.
+        if($port !== NULL && (!is_numeric($port) || $port < 1 || $port > 65535))
+            throw new \Exception("Unable to create new Jenkins management class; Invalid port provided.");
 
         //make sure that, if provided, the username is not empty.
         if($user !== NULL && strlen($user) < 1)
@@ -70,10 +74,6 @@ class Jenkins
         //make sure that, if provided, the username is not empty.
         if($token !== NULL && strlen($token) < 1)
             throw new \Exception("Unable to create new Jenkins management class; Invalid token provided.");
-
-        //make sure that, if provided, the username is not empty.
-        if($port !== NULL && (!is_numeric($port) || $port < 1 || $port > 65535))
-            throw new \Exception("Unable to create new Jenkins management class; Invalid port provided.");
 
 
         //use HTTP or HTTPS based on provided argument.

--- a/src/Jenkins.php
+++ b/src/Jenkins.php
@@ -11,7 +11,7 @@ class Jenkins
     private $baseUrl;
 
     /**
-     * @var null
+     * @var stdClass
      */
     private $jenkins = null;
 
@@ -132,7 +132,7 @@ class Jenkins
         } else {
             try {
                 $this->getQueue();
-            } catch (RuntimeException $e) {
+            } catch (\RuntimeException $e) {
                 //en cours de lancement de jenkins, on devrait passer par là
                 return false;
             }


### PR DESCRIPTION
Instead of asking the developer to formulate their own URL to contact the Jenkins API, ask developers to provide URL parts, and leave the construct method responsible for piecing the parameters together in order to formulate the URL.